### PR TITLE
Use head and tail from busybox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         locales \
         unzip \
+        busybox \
 	&& rm -r /var/lib/apt/lists/* \
 	&& sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
 	&& locale-gen \

--- a/src/Component.php
+++ b/src/Component.php
@@ -92,11 +92,11 @@ class Component extends BaseComponent
     private function skipLinesInFile(string $sourcePath, string $destinationPath, string $direction, int $lines): void
     {
         if ($direction === 'bottom') {
-            $copyCommand = "head -n -" . $lines . " " .
+            $copyCommand = "busybox head -n -" . $lines . " " .
                 escapeshellarg($sourcePath) . " > " .
                 escapeshellarg($destinationPath);
         } else {
-            $copyCommand = "tail -n +" . ($lines + 1) . " " .
+            $copyCommand = "busybox tail -n +" . ($lines + 1) . " " .
                 escapeshellarg($sourcePath) . " > " .
                 escapeshellarg($destinationPath);
         }


### PR DESCRIPTION
Problem:
- `6GB`! of memory is not enough for the processor.
- We can try `busybox` implementation of head and tail display.